### PR TITLE
Upgrade to v7.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Shipped version:** 7.2.1~ynh1
+**Shipped version:** 7.2.2~ynh1
 
 **Demo:** <https://demo.koel.dev>
 

--- a/README_es.md
+++ b/README_es.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Versión actual:** 7.2.1~ynh1
+**Versión actual:** 7.2.2~ynh1
 
 **Demo:** <https://demo.koel.dev>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Paketatutako bertsioa:** 7.2.1~ynh1
+**Paketatutako bertsioa:** 7.2.2~ynh1
 
 **Demoa:** <https://demo.koel.dev>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Un simple service web de streaming audio personnel, écrit en Vue pour le client
 Destiné aux développeurs web, Koel utilise certaines des technologies web les plus modernes pour accomplir son travail.
 
 
-**Version incluse :** 7.2.1~ynh1
+**Version incluse :** 7.2.2~ynh1
 
 **Démo :** <https://demo.koel.dev>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Versión proporcionada:** 7.2.1~ynh1
+**Versión proporcionada:** 7.2.2~ynh1
 
 **Demo:** <https://demo.koel.dev>
 

--- a/README_id.md
+++ b/README_id.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Versi terkirim:** 7.2.1~ynh1
+**Versi terkirim:** 7.2.2~ynh1
 
 **Demo:** <https://demo.koel.dev>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Geleverde versie:** 7.2.1~ynh1
+**Geleverde versie:** 7.2.2~ynh1
 
 **Demo:** <https://demo.koel.dev>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Dostarczona wersja:** 7.2.1~ynh1
+**Dostarczona wersja:** 7.2.2~ynh1
 
 **Demo:** <https://demo.koel.dev>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**Поставляемая версия:** 7.2.1~ynh1
+**Поставляемая версия:** 7.2.2~ynh1
 
 **Демо-версия:** <https://demo.koel.dev>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -23,7 +23,7 @@ Koel is a simple web-based personal audio streaming service written in Vue on th
 Targeting web developers, Koel embraces some of the more modern web technologies to do its job.
 
 
-**分发版本：** 7.2.1~ynh1
+**分发版本：** 7.2.2~ynh1
 
 **演示：** <https://demo.koel.dev>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Koel"
 description.en = "Simple web-based personal audio streaming service"
 description.fr = "Simple service web de streaming audio personnel"
 
-version = "7.2.1~ynh1"
+version = "7.2.2~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -48,8 +48,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/koel/koel/releases/download/v7.2.1/koel-v7.2.1.tar.gz"
-    sha256 = "747b848714816f3e8fd9b5bcd11285ed47915473217cb3c8c51a053d3d3c80d4"
+    url = "https://github.com/koel/koel/releases/download/v7.2.2/koel-v7.2.2.tar.gz"
+    sha256 = "8aaf507cdc5d85e5d3215384de69232c62c9e9dca1ef8e56523c637bc875130f"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "^koel-v.*tar.gz$"


### PR DESCRIPTION
Upgrade sources
- `main` v7.2.2: https://github.com/koel/koel/releases/tag/v7.2.2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
